### PR TITLE
Add throttling and caching for image transformations

### DIFF
--- a/src/images/images.controller.ts
+++ b/src/images/images.controller.ts
@@ -2,8 +2,6 @@ import { ApiBearerAuth, ApiTags } from '@nestjs/swagger';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { Response } from 'express';
 import { ThrottlerGuard } from '@nestjs/throttler';
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
-import { Cache } from 'cache-manager';
 import {
   Controller,
   Get,
@@ -18,7 +16,6 @@ import {
   Res,
   Query,
   BadRequestException,
-  Inject,
 } from '@nestjs/common';
 
 import { ImagesService } from './images.service';
@@ -34,10 +31,7 @@ import { Public } from 'src/public/public.decorator';
 @UseGuards(JwtAuthGuard)
 @Controller('images')
 export class ImagesController {
-  constructor(
-    private readonly imagesService: ImagesService,
-    @Inject(CACHE_MANAGER) private cacheManager: Cache,
-  ) {}
+  constructor(private readonly imagesService: ImagesService) {}
 
   private validateTransformations(dto: TransformImageDto) {
     const hasResize =

--- a/src/transformed-images/transformed-images.controller.ts
+++ b/src/transformed-images/transformed-images.controller.ts
@@ -19,6 +19,7 @@ import { ViewOrDownloadImageDto } from 'src/images/dto/view-or-download-image.dt
 import { Public } from 'src/public/public.decorator';
 import { UserId } from 'src/user-id/user-id.decorator';
 import { TransformImageDto } from 'src/images/dto/transform-image.dto';
+import { ThrottlerGuard } from '@nestjs/throttler';
 
 @ApiTags('TransformedImages')
 @ApiBearerAuth()
@@ -83,6 +84,7 @@ export class TransformedImagesController {
     }
   }
 
+  @UseGuards(ThrottlerGuard)
   @Post(':id/transform')
   transform(
     @UserId() userId: string,


### PR DESCRIPTION
Introduce a throttling guard for the transform endpoint and refactor validation for transformations and order integrity. Implement caching for transformed images to enhance performance and reduce redundant transformations.